### PR TITLE
fix deprecated redis pipeline command

### DIFF
--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
@@ -48,9 +48,9 @@ module SidekiqUniqueJobs
                 expires_at = unique_job_expiration || SidekiqUniqueJobs.config.default_expiration
                 expires_at = ((Time.at(item['at']) - Time.now.utc) + expires_at).to_i if item['at']
 
-                unique = conn.multi do
+                unique = conn.multi do |pipeline|
                   # set value of 2 for scheduled jobs, 1 for queued jobs.
-                  conn.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
+                  pipeline.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
                 end
               end
             end


### PR DESCRIPTION
<img width="1360" alt="image" src="https://github.com/instacart/sidekiq-unique-jobs/assets/63614999/e2f42991-421d-42da-bf18-c4e8b9d0f3a6">


https://instacart.datadoghq.com/logs?query=redis.multi%20do%20&agg_q=status%2Cservice&agg_q_source=base%2Cbase&cols=host%2Cservice&context_event=AY6hHUmPAACOnIFM1IfwQwJK&index=&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=time%2Cdesc&top_n=10%2C10&top_o=top%2Ctop&viz=&x_missing=true%2Ctrue&from_ts=1712014620898&to_ts=1712101020898&live=true

https://instacart.datadoghq.com/logs?query=redis.multi%20do%20%7Cpipeline%7C%20&agg_q=status%2Cservice&agg_q_source=base%2Cbase&cols=host%2Cservice&context_event=AY6hHUmPAACOnIFM1IfwQwJK&index=&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=time%2Cdesc&top_n=10%2C10&top_o=top%2Ctop&viz=&x_missing=true%2Ctrue&from_ts=1712014620898&to_ts=1712101020898&live=true
We have 40M error logs per day because of this message