### PR TITLE
Minor bug fixes

### DIFF
--- a/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
+++ b/lib/sidekiq_unique_jobs/middleware/client/strategies/unique.rb
@@ -48,9 +48,9 @@ module SidekiqUniqueJobs
                 expires_at = unique_job_expiration || SidekiqUniqueJobs.config.default_expiration
                 expires_at = ((Time.at(item['at']) - Time.now.utc) + expires_at).to_i if item['at']
 
-                unique = conn.multi do
+                unique = conn.multi do |rr|
                   # set value of 2 for scheduled jobs, 1 for queued jobs.
-                  conn.setex(payload_hash, expires_at, item['at'] ? 2 : 1)
+                  rr.setex(payload_hash, expires_at.to_i, item['at'] ? 2 : 1)
                 end
               end
             end


### PR DESCRIPTION
* Fix invalid use of #multi (breaks on redis-rb 5)
* Ensure ttl is passed as int (breaks on redis-client)